### PR TITLE
Add accessible dashboard with calendar, notes, todos, and logging

### DIFF
--- a/AIO.js
+++ b/AIO.js
@@ -1,1 +1,144 @@
+// Einfaches AIO Tool mit Logging
 
+function debugLog(msg) {
+  const out = document.getElementById('log-output');
+  const time = new Date().toLocaleTimeString();
+  const line = `[${time}] ${msg}\n`;
+  out.textContent += line;
+  out.scrollTop = out.scrollHeight;
+  console.log(line);
+}
+
+function updateDashboard(todoCount, noteCount) {
+  document.getElementById('todo-count').textContent = todoCount;
+  document.getElementById('note-count').textContent = noteCount;
+}
+
+function initNotes() {
+  const textarea = document.getElementById('notes');
+  const saveBtn = document.getElementById('save-note');
+  const stored = localStorage.getItem('notes') || '';
+  textarea.value = stored;
+  document.getElementById('note-count').textContent = stored.trim() ? 1 : 0;
+
+  saveBtn.addEventListener('click', () => {
+    localStorage.setItem('notes', textarea.value);
+    const count = textarea.value.trim() ? 1 : 0;
+    updateDashboard(getTodos().length, count);
+    debugLog('Notizen gespeichert');
+  });
+}
+
+function getTodos() {
+  return JSON.parse(localStorage.getItem('todos') || '[]');
+}
+
+function getArchive() {
+  return JSON.parse(localStorage.getItem('archive') || '[]');
+}
+
+function saveTodos(todos, archive) {
+  localStorage.setItem('todos', JSON.stringify(todos));
+  localStorage.setItem('archive', JSON.stringify(archive));
+  updateDashboard(todos.length, document.getElementById('note-count').textContent);
+}
+
+function renderTodos() {
+  const list = document.getElementById('todo-list');
+  const archiveList = document.getElementById('todo-archive');
+  list.innerHTML = '';
+  archiveList.innerHTML = '';
+  const todos = getTodos();
+  const archive = getArchive();
+
+  todos.forEach((t, idx) => {
+    const li = document.createElement('li');
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.id = `todo-${idx}`;
+    cb.addEventListener('change', () => {
+      archive.push(t);
+      todos.splice(idx, 1);
+      saveTodos(todos, archive);
+      renderTodos();
+      debugLog(`Aufgabe archiviert: ${t.text}`);
+    });
+    const label = document.createElement('label');
+    label.htmlFor = cb.id;
+    label.textContent = `${t.text} (${t.date || 'kein Datum'})`;
+    li.appendChild(cb);
+    li.appendChild(label);
+    list.appendChild(li);
+  });
+
+  archive.forEach(t => {
+    const li = document.createElement('li');
+    li.textContent = `${t.text} (${t.date || 'kein Datum'})`;
+    archiveList.appendChild(li);
+  });
+
+  updateDashboard(todos.length, document.getElementById('note-count').textContent);
+}
+
+function initTodos() {
+  renderTodos();
+  const form = document.getElementById('todo-form');
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const text = document.getElementById('todo-text').value.trim();
+    const date = document.getElementById('todo-date').value;
+    if (!text) return;
+    const todos = getTodos();
+    todos.push({ text, date });
+    saveTodos(todos, getArchive());
+    renderTodos();
+    form.reset();
+    debugLog(`Aufgabe hinzugefügt: ${text}`);
+  });
+}
+
+function initCalendar() {
+  const calDiv = document.getElementById('calendar');
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth();
+  const first = new Date(year, month, 1);
+  const last = new Date(year, month + 1, 0);
+  const table = document.createElement('table');
+  const headerRow = document.createElement('tr');
+  const days = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'];
+  days.forEach(d => {
+    const th = document.createElement('th');
+    th.textContent = d;
+    headerRow.appendChild(th);
+  });
+  table.appendChild(headerRow);
+  let row = document.createElement('tr');
+  for (let i = 1; i < (first.getDay() || 7); i++) {
+    row.appendChild(document.createElement('td'));
+  }
+  for (let d = 1; d <= last.getDate(); d++) {
+    const cell = document.createElement('td');
+    cell.textContent = d;
+    row.appendChild(cell);
+    if ((first.getDay() + d - 1) % 7 === 0) {
+      table.appendChild(row);
+      row = document.createElement('tr');
+    }
+  }
+  if (row.children.length) table.appendChild(row);
+  calDiv.appendChild(table);
+  debugLog('Kalender geladen');
+}
+
+function initHeader() {
+  document.getElementById('today').textContent = new Date().toLocaleDateString();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initHeader();
+  initNotes();
+  initTodos();
+  initCalendar();
+  debugLog('System gestartet');
+});

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # AIO-Tool
+
+Ein einfaches Dashboard für Aufgaben, Notizen und Kalender. Alles läuft im Browser und speichert die Daten lokal.
+
+## Start
+
+1. Starte einen kleinen Webserver:
+   ```
+   python3 -m http.server 8000
+   ```
+2. Öffne im Browser: [http://localhost:8000](http://localhost:8000)
+
+## Module
+- **Dashboard:** zeigt Anzahl offener Todos und Notizen.
+- **Todo:** Aufgaben mit Datum hinzufügen, abhaken und archivieren.
+- **Notizen:** kurzer Text, der dauerhaft im Browser gespeichert wird.
+- **Kalender:** aktuelle Monatsansicht.
+- **Debug-Log:** einfache Protokollausgabe aller Aktionen.

--- a/index.html
+++ b/index.html
@@ -1,1 +1,56 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AIO Dashboard</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>AIO-Dashboard</h1>
+    <p>Hier verwaltest du Aufgaben, Notizen und den Kalender. Alles wird automatisch im Browser gespeichert.</p>
+    <p id="today" aria-live="polite"></p>
+  </header>
 
+  <main>
+    <section id="dashboard" aria-labelledby="dashboard-heading">
+      <h2 id="dashboard-heading">Übersicht</h2>
+      <p>Offene Aufgaben: <span id="todo-count">0</span></p>
+      <p>Notizen gespeichert: <span id="note-count">0</span></p>
+    </section>
+
+    <section id="todo-module" aria-labelledby="todo-heading">
+      <h2 id="todo-heading">Aufgaben (Todos)</h2>
+      <form id="todo-form">
+        <label for="todo-text">Aufgabe</label>
+        <input id="todo-text" type="text" aria-label="Aufgabenbeschreibung" required />
+        <label for="todo-date">Datum</label>
+        <input id="todo-date" type="date" aria-label="Fälligkeitsdatum" />
+        <button type="submit">Hinzufügen</button>
+      </form>
+      <ul id="todo-list"></ul>
+      <h3>Archiv</h3>
+      <ul id="todo-archive"></ul>
+    </section>
+
+    <section id="notes-module" aria-labelledby="notes-heading">
+      <h2 id="notes-heading">Notizen</h2>
+      <textarea id="notes" rows="5" aria-label="Notiztext"></textarea>
+      <button id="save-note">Speichern</button>
+    </section>
+
+    <section id="calendar-module" aria-labelledby="calendar-heading">
+      <h2 id="calendar-heading">Kalender</h2>
+      <div id="calendar"></div>
+    </section>
+
+    <section id="log-module" aria-labelledby="log-heading">
+      <h2 id="log-heading">Debug-Log</h2>
+      <pre id="log-output" aria-live="polite"></pre>
+    </section>
+  </main>
+
+  <script src="AIO.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,1 +1,44 @@
+body {
+  font-family: Arial, sans-serif;
+  font-size: 1.2rem;
+  background: #fff;
+  color: #000;
+  line-height: 1.6;
+}
 
+header, section {
+  margin-bottom: 1.5rem;
+}
+
+button {
+  background: #000;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+button:focus, input:focus, textarea:focus {
+  outline: 3px solid #005fcc;
+}
+
+#calendar table {
+  border-collapse: collapse;
+}
+
+#calendar th, #calendar td {
+  border: 1px solid #000;
+  padding: 0.3rem;
+  text-align: center;
+}
+
+#todo-list li, #todo-archive li {
+  margin: 0.3rem 0;
+}
+
+#log-output {
+  background: #f0f0f0;
+  padding: 0.5rem;
+  height: 150px;
+  overflow-y: auto;
+}

--- a/todo.txt
+++ b/todo.txt
@@ -1,0 +1,3 @@
+- [x] Dashboard mit Kalender, Notizen, Todo und Logging
+- [ ] Sprachausgabe für Screenreader erweitern
+- [ ] Datenexport als Datei


### PR DESCRIPTION
## Summary
- build accessible dashboard with overview, todo list, notes, calendar and debug log
- add high-contrast styles and focus outlines for visually impaired users
- document usage and future tasks in README and todo list

## Testing
- `node --check AIO.js`


------
https://chatgpt.com/codex/tasks/task_e_689dc58e00b4832587d488e54c0df1ef